### PR TITLE
Feat/update 2

### DIFF
--- a/docs/get-started/setup.md
+++ b/docs/get-started/setup.md
@@ -11,8 +11,8 @@ By the end of this guide, you'll have a local development environment that has:
 1. a running NodeJS API server, which'll hot-reload upon changes
 1. a running React web app, which'll also hot-reload upon changes
 1. a MongoDB instance with your calendar data
-1. a CLI, which you can use to create a distributable artifact
-1. `package.json` scripts to run local tests
+1. a CLI for builds and maintenance tasks
+1. `package.json` scripts to run targeted tests
 
 You'll then be ready to play with the local web app and test any changes you'd like to make.
 
@@ -23,8 +23,14 @@ Ready? Let's go!
 Before you begin, ensure you have:
 
 - **Node.js >= 24.0.0** installed ([Download Node.js](https://nodejs.org/))
-- **Yarn** package manager installed
+- **Yarn 4** available via Corepack
 - A code editor (VS Code recommended)
+
+Enable Corepack if you have not already:
+
+```bash
+corepack enable
+```
 
 ## Get the Code
 
@@ -40,7 +46,7 @@ Before you begin, ensure you have:
 
 These files contain your custom and sensitive information. Create them now so you can fill values in as you set up third-party accounts.
 
-1. Copy `compass/packages/backend/.env.local.example` and save as `compass/packages/backend/.env.local`.
+1. Copy `compass/packages/backend/.env.local.example` and save as `compass/packages/backend/.env`.
 2. Read through the comments to familiarize yourself with the environment variables.
 3. Keep `LOCAL_WEB_URL=http://localhost:9080` in `.env.local`. Compass uses it for local browser cleanup flows and password reset links.
 4. If you plan on deploying Compass, also create `compass/packages/backend/.env.staging` and `compass/packages/backend/.env.production`.
@@ -77,7 +83,7 @@ To use Google OAuth, create a Google Cloud Platform project and setup an OAuth s
    - Select Web Application
    - Add to Authorized JavaScript origins: `http://localhost:9080`
    - Add to Authorized redirect URIs: `http://localhost:3000`
-   - Copy the Client ID and Secret to your `.env.local` file
+   - Copy the Client ID and Secret to your backend env file
 5. Enable the Google Calendar API in your GCP project
    - Navigate to the [API Library](https://console.cloud.google.com/apis/library) in your Google Cloud project
    - Use the search bar at the top of the page to search for "Google Calendar API"
@@ -101,8 +107,12 @@ Compass connects to MongoDB through the NodeJS driver.
 1. Create a free [MongoDB Atlas account](https://www.mongodb.com/cloud/atlas/register)
 2. Get your Node.js driver [connection string](https://www.mongodb.com/docs/drivers/node/current/fundamentals/connection/connect/#std-label-node-connect-to-mongodb)
 3. When you get your connection string, scroll down to the Network access in the left sidebar and add your current ip address. Make sure you always include your ip address when you switch networks because your device ip v4 address changes from one ISP to another and from time to time.
+   <<<<<<< HEAD
 4. Add connection string to your `.env.local` file
-5. **Recommended**: Install [MongoDB Compass](https://www.mongodb.com/products/compass) desktop app to visually inspect and manage your database during local development. You can connect to your MongoDB Atlas instance using the same connection string from your `.env.local` file.
+5. # **Recommended**: Install [MongoDB Compass](https://www.mongodb.com/products/compass) desktop app to visually inspect and manage your database during local development. You can connect to your MongoDB Atlas instance using the same connection string from your `.env.local` file.
+6. Add connection string to your backend env file
+7. **Recommended**: Install [MongoDB Compass](https://www.mongodb.com/products/compass) desktop app to visually inspect and manage your database during local development. You can connect to your MongoDB Atlas instance using the same connection string from your `.env` file.
+   > > > > > > > main
 
 ### Supertokens
 
@@ -129,7 +139,7 @@ Pfew! That was a lot of setup. Now for the fun part. Run these commands from the
 1. Install dependencies
 
    ```bash
-   yarn
+   yarn install --immutable
    ```
 
 2. Start the backend in dev mode
@@ -149,7 +159,6 @@ Pfew! That was a lot of setup. Now for the fun part. Run these commands from the
 5. Sign in with one of your authorized test Google accounts
 
    If all goes well, Compass will:
-
    - Create a new user in MongoDB
    - Start a user session with Supertokens
    - Add the user's email to Kit (if enabled)
@@ -160,18 +169,20 @@ Pfew! That was a lot of setup. Now for the fun part. Run these commands from the
 
 ## Development Workflow
 
-### Hot Reloading
+### Pick the Lightest Dev Mode
 
-Both the frontend and backend support hot reloading during development:
+You do not always need the full stack running:
 
-- **Frontend**: The React app running on `http://localhost:9080` will automatically reload when you make changes to files in `packages/web`
-- **Backend**: The Node.js API server running on `http://localhost:3000` will automatically restart when you make changes to files in `packages/backend`
+- **Frontend-only work**: Run `yarn dev:web` for layout, local interactions, and many task workflows.
+- **Backend or auth work**: Run `yarn dev:backend` when your change depends on MongoDB, sessions, Google OAuth, sync, or websockets.
+
+When both are running, each process hot-reloads as you edit files in its package.
 
 ### Common Development Tasks
 
 - **Viewing logs**: Check the terminal where you ran `yarn dev:backend` for API logs and the terminal where you ran `yarn dev:web` for build logs
-- **Testing changes**: After making changes, test them in the browser. The app should hot-reload automatically
-- **Database inspection**: MongoDB collections are created automatically. We recommend using the [MongoDB Compass](https://www.mongodb.com/products/compass) desktop app to visually inspect your database, view collections, documents, and run queries during local development. Connect using the same MongoDB connection string from your `.env.local` file.
+- **Testing changes**: Prefer the smallest relevant test command first, such as `yarn test:web` or `yarn test:backend`
+- **Database inspection**: MongoDB collections are created automatically. We recommend using the [MongoDB Compass](https://www.mongodb.com/products/compass) desktop app to visually inspect your database, view collections, documents, and run queries during local development. Connect using the same MongoDB connection string from your backend env file.
 - **Clearing user data**: Use `yarn cli delete -u <email>` to clear a user's data and start fresh (see [CLI guide](../guides/cli.md))
 
 ### Debugging Tips
@@ -179,6 +190,7 @@ Both the frontend and backend support hot reloading during development:
 - Use browser DevTools to debug the frontend React app
 - Use Redux DevTools browser extension to inspect Redux state
 - Check backend logs in the terminal for API errors
+- Check backend health with `curl -i http://localhost:3000/api/health` when startup or Mongo connectivity looks suspicious
 - Use MongoDB Compass desktop app to inspect database collections and documents, run queries, and verify data changes in real-time
 - For webhook testing during development, set up Ngrok (see Optional Accounts section)
 

--- a/docs/get-started/setup.md
+++ b/docs/get-started/setup.md
@@ -36,13 +36,22 @@ Before you begin, ensure you have:
    cd compass
    ```
 
-## Setup the `.env` files
+## Setup the environment files
 
-This is the file that contains your custom and sensitive information. We're creating the file now so we can update the values as we set up our third-party accounts.
+These files contain your custom and sensitive information. Create them now so you can fill values in as you set up third-party accounts.
 
 1. Copy `compass/packages/backend/.env.local.example` and save as `compass/packages/backend/.env.local`.
 2. Read through the comments to familiarize yourself with the environment variables.
-3. If you plan on deploying Compass to a production environment, also create `.env.staging` and `.env.production` for further separation of environments.
+3. Keep `LOCAL_WEB_URL=http://localhost:9080` in `.env.local`. Compass uses it for local browser cleanup flows and password reset links.
+4. If you plan on deploying Compass, also create `compass/packages/backend/.env.staging` and `compass/packages/backend/.env.production`.
+
+Compass uses explicit env file names:
+
+- `.env.local` for local development
+- `.env.staging` for staging
+- `.env.production` for production
+
+The root scripts load `packages/backend/.env.local` automatically. That includes `yarn dev:backend`, `yarn dev:web`, and `yarn cli`.
 
 ## Setup Accounts
 
@@ -93,7 +102,7 @@ Compass connects to MongoDB through the NodeJS driver.
 2. Get your Node.js driver [connection string](https://www.mongodb.com/docs/drivers/node/current/fundamentals/connection/connect/#std-label-node-connect-to-mongodb)
 3. When you get your connection string, scroll down to the Network access in the left sidebar and add your current ip address. Make sure you always include your ip address when you switch networks because your device ip v4 address changes from one ISP to another and from time to time.
 4. Add connection string to your `.env.local` file
-5. **Recommended**: Install [MongoDB Compass](https://www.mongodb.com/products/compass) desktop app to visually inspect and manage your database during local development. You can connect to your MongoDB Atlas instance using the same connection string from your `.env` file.
+5. **Recommended**: Install [MongoDB Compass](https://www.mongodb.com/products/compass) desktop app to visually inspect and manage your database during local development. You can connect to your MongoDB Atlas instance using the same connection string from your `.env.local` file.
 
 ### Supertokens
 
@@ -111,7 +120,7 @@ Supertokens will provision the auth infrastructure in AWS for you, presenting a 
 2. Click trough the onboarding steps
    - If prompted for a recipe, select Passwordless
 3. Select the Managed Core option
-4. After your instance is configured, copy the connection URI and API key to your `.env` file
+4. After your instance is configured, copy the connection URI and API key to your `.env.local` file
 
 ## Start in Dev Mode
 
@@ -145,7 +154,7 @@ Pfew! That was a lot of setup. Now for the fun part. Run these commands from the
    - Start a user session with Supertokens
    - Add the user's email to Kit (if enabled)
    - Import events from the user's `primary` Google Calendar into MongoDB
-   - Setup a sync channel to receive Google Calendar webhook notifications for the duration specified in the `.env` (if using HTTPS)
+   - Setup a sync channel to receive Google Calendar webhook notifications for the duration specified in `.env.local` (if using HTTPS)
 
 6. Make a change to the frontend and backend code to confirm each hot reloads
 
@@ -196,7 +205,7 @@ You can skip this if you don't want to add emails to Kit.
 1. Create a free [Kit account](https://kit.com/)
 2. Get your API secret from the Account Settings
 3. Get your Kit tag ID. You can find this in the URL of the tag page
-4. Add the API secret and tag ID to your `.env` file
+4. Add the API secret and tag ID to your `.env.local` file
 
 ### Calendar Sync Proxy: Ngrok
 
@@ -207,7 +216,7 @@ You can skip this if you're not working on, or going to test the webhook functio
 1. Create a free [Ngrok account](https://dashboard.ngrok.com/signup/)
 2. Get your [Authtoken](https://dashboard.ngrok.com/get-started/your-authtoken) from the Ngrok Dashboard
 3. Create a [Static Domain](https://dashboard.ngrok.com/domains) from the Ngrok Dashboard
-4. Add the Authtoken (`NGROK_AUTHTOKEN`) and Static Domain (`NGROK_DOMAIN`) to your `.env` file
+4. Add the Authtoken (`NGROK_AUTHTOKEN`) and Static Domain (`NGROK_DOMAIN`) to your `.env.local` file
 
 ### Analytics: PostHog
 
@@ -223,7 +232,7 @@ You can skip this if you don't want to collect analytics or error tracking data.
 2. Create a new project in your PostHog dashboard
 3. Get your Project API Key from the Project Settings
 4. Get your PostHog Host URL (usually `https://app.posthog.com` for PostHog Cloud, or your self-hosted URL)
-5. Add the API Key (`POSTHOG_KEY`) and Host URL (`POSTHOG_HOST`) to your `.env` file
+5. Add the API Key (`POSTHOG_KEY`) and Host URL (`POSTHOG_HOST`) to your `.env.local` file
 
 Alternatively, if you prefer to self-host PostHog:
 

--- a/docs/guides/build.md
+++ b/docs/guides/build.md
@@ -18,6 +18,20 @@ The CLI will prompt you to:
 2. Specify the environment (`local`, `staging`, or `production`)
 3. Optionally provide a Google Client ID to inject into the build
 
+## Environment Files
+
+`yarn cli` loads `packages/backend/.env.local` before the CLI starts. That means local CLI workflows automatically use values like `BASEURL` and `LOCAL_WEB_URL` from that file.
+
+Builds themselves use environment-specific files from `packages/backend`:
+
+- `local` loads `.env.local`
+- `staging` loads `.env.staging`
+- `production` loads `.env.production`
+
+For web builds, webpack reads the matching file from `packages/backend`. If that file does not exist, webpack falls back to the current shell environment.
+
+For backend builds, the selected env file is copied into `build/node/.env`.
+
 ### Build Options
 
 You can also use command-line options:
@@ -36,11 +50,13 @@ yarn cli build nodePckgs -e staging
 yarn cli build web -e production -c YOUR_CLIENT_ID
 ```
 
+For local builds, `BASEURL` should usually point at your local API, for example `http://localhost:3000/api`.
+
 ### Build Output
 
 The compiled artifacts will be placed in the `/build` directory:
 
-- Frontend build: `/build/packages/web/` (static files ready to serve)
-- Backend build: `/build/packages/backend/` (compiled JavaScript files)
+- Frontend build: `/build/web/` (static files ready to serve)
+- Backend build: `/build/node/` (compiled JavaScript files plus the selected `.env` file)
 
 See [the CLI page](./cli.md) for more details about the CLI commands and options.

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -1,11 +1,10 @@
 # CLI
 
-The Compass CLI was built to streamline common development tasks.
-It exists within the `scripts` package and is run from the root directory.
+The Compass CLI streamlines builds and a small set of maintenance workflows. Run it from the root directory.
 
 ## All CLI options
 
-To see all the supported commands, run `yarn cli -h` from the root directory
+To see all the supported commands, run `yarn cli --help` from the root directory
 
 ```bash
 $ yarn cli -h
@@ -88,7 +87,6 @@ To delete a user's Compass data:
 3. After backend deletion completes, you'll be prompted to clear browser data:
 
 4. If you confirm, it'll open the provided cleanup URL in your browser:
-
    - The cleanup page will automatically:
      - Log you out of your session
      - Clear all localStorage data
@@ -122,20 +120,28 @@ The cleanup will run automatically when you visit the URL.
 
 ## Database Migrations
 
-The CLI provides commands for managing database schema migrations:
+The CLI wraps the repo's migration and seeding flows.
 
 ### Running Migrations
 
 ```bash
-yarn cli migrate
+yarn cli migrate pending
+yarn cli migrate up
+yarn cli migrate executed
 ```
 
-This runs pending database schema migrations to update your database structure.
+Common subcommands include `up`, `down`, `pending`, `executed`, and `create`.
 
 ### Seeding the Database
 
 ```bash
-yarn cli seed
+yarn cli seed <subcommand>
 ```
 
-This runs seed migrations to populate the database with initial or test data.
+Use seed commands for database seeder flows built on the same framework as migrations.
+
+## Safety Tips
+
+- Treat `delete` as destructive.
+- Read the command help before running unfamiliar migration or seed operations.
+- Confirm whether you need `web` or `nodePckgs` before building.

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -13,16 +13,18 @@ $ yarn cli -h
 Usage: cli [options] [command]
 
 Options:
-  -f, --force                        force operation, no cautionary prompts
   -h, --help                         display help for command
 
 Commands:
   build [options] [nodePckgs | web]  build compass package
   delete [options]                   delete user data from compass database
-  migrate [options]                   run database schema migrations
-  seed [options]                      run seed migrations to populate the database with data
+  migrate                            run database schema migrations
+  seed                               run seed migrations to populate the
+                                     database with data
   help [command]                     display help for command
 ```
+
+`yarn cli` automatically loads `packages/backend/.env.local` before the CLI starts.
 
 To see the options for a specific command, run `yarn cli <command> -h`
 
@@ -42,6 +44,21 @@ Options:
   -h, --help                                display help for command
 ```
 
+Delete command options:
+
+```bash
+$ yarn cli delete -h
+
+Usage: cli delete [options]
+
+delete user data from compass database
+
+Options:
+  -u, --user [id | email]  specify which user to run script for
+  -f, --force              force deletion without confirmation prompts
+  -h, --help               display help for command
+```
+
 ## Cleaning User Data
 
 Since user data is stored across multiple collections and involves sessions and authorization, it's often best to start from scratch when things go awry in development.
@@ -49,6 +66,12 @@ Since user data is stored across multiple collections and involves sessions and 
 The CLI's delete workflow deletes the user's Compass data from the backend database. It also provides an automated way to clear browser-side data (session cookies, localStorage, and IndexedDB).
 
 The CLI's delete workflow only deletes the user's Compass data. It does not delete their Google Calendar data.
+
+The cleanup URL now comes from explicit web URLs:
+
+- Local: `LOCAL_WEB_URL`
+- Staging: `STAGING_WEB_URL`
+- Production: `PROD_WEB_URL`
 
 ### Steps
 
@@ -92,6 +115,8 @@ When using `--force`, the CLI will:
 If you skip the cleanup during account deletion, you can manually visit the cleanup URL later:
 
 - **Local**: `http://localhost:9080/cleanup` (or your dev server port)
+- **Staging**: `<STAGING_WEB_URL>/cleanup`
+- **Production**: `<PROD_WEB_URL>/cleanup`
 
 The cleanup will run automatically when you visit the URL.
 

--- a/docs/guides/deploy.md
+++ b/docs/guides/deploy.md
@@ -6,9 +6,11 @@ In order to allow users to sign-in and sync their Google Calendars, you'll need 
 
 Then you'll need to update a few configuration values:
 
-1. Update `BASEURL` in `packages/backend/.env.production` with your URI
-2. Add the URL to the `CORS` list in `.env.production`
-3. Add your domain to the list of allowed redirect URIs in your Google Cloud project
+1. Put your runtime values in `packages/backend/.env.production` for production or `packages/backend/.env.staging` for staging.
+2. Set `BASEURL` to your public API base URL, including `/api`.
+3. Set `PROD_WEB_URL` or `STAGING_WEB_URL` to the public web app URL for that environment.
+4. Add the deployed web URL to the `CORS` list in the matching env file.
+5. Add your deployed web origin and redirect URIs to your Google Cloud project.
 
 ## Web
 
@@ -18,7 +20,7 @@ We use a Nginx reverse proxy to serve the static assets and handle SSL. This req
 
 ## Backend (API)
 
-After running [the build CLI for the backend](./build), you'll have a bunch of Node files in the `/build` directory. You can copy these to your server and run them directly like a normal Node app -- by running `node build/packages/backend/src/app.js`. Similar to the web app, it's up to you to decide how to configure your Node server. You could turn it into a container and deploy it on a PaaS. Or you could run it in a VM on a cloud provider and use a tool like `pm2` to manage it. Depending on the PaaS you choose, you might need to configure the webserver to support WebSocket connections over a reverse proxy.
+After running [the build CLI for the backend](./build), the compiled backend is written to `/build/node` and includes the selected environment file as `/build/node/.env`. You can copy that directory to your server and run the API like a normal Node app with `node build/node/packages/backend/src/app.js`. Similar to the web app, it's up to you to decide how to configure your Node server. You could turn it into a container and deploy it on a PaaS. Or you could run it in a VM on a cloud provider and use a tool like `pm2` to manage it. Depending on the PaaS you choose, you might need to configure the webserver to support WebSocket connections over a reverse proxy.
 
 Getting the backend production-ready can be a headache. If you'd like to get up-and-running quickly and want it done right, ask about our white-glove install service.
 

--- a/docs/guides/test.md
+++ b/docs/guides/test.md
@@ -4,52 +4,58 @@ This doc explains how to run tests locally. For information on writing tests, se
 
 ## Automated Testing
 
-### How to run tests locally
+### Start with the Smallest Relevant Check
 
-Use these commands from the root directory to run the unit and integration tests locally:
+Most changes do not require the entire test suite. Start with the smallest command that covers your change, then widen only if the change crosses package boundaries.
+
+Use these commands from the repo root:
 
 ```bash
-yarn test           # runs all tests
-
-yarn test:web       # runs web tests
-
-yarn test:backend   # runs backend tests
-
-yarn test:core      # runs core tests
-
-yarn test:scripts   # runs scripts tests
-
-yarn test:e2e       # runs e2e tests
+yarn test:web       # web UI and interaction tests
+yarn test:backend   # backend route and service tests
+yarn test:core      # shared domain logic tests
+yarn test:scripts   # CLI, migrations, and script tests
+yarn type-check     # repository-wide TypeScript check
+yarn test:e2e       # Playwright end-to-end flows
 ```
+
+Use `yarn test` only when you explicitly want the full Jest suite.
+
+### What to Run
+
+- **Web-only UI change**: `yarn test:web`
+- **Backend route or service change**: `yarn test:backend`
+- **Shared types or business logic**: `yarn test:core`
+- **CLI, migration, or seeder change**: `yarn test:scripts`
+- **Cross-cutting changes**: combine the relevant commands and add `yarn type-check`
+- **Critical user flows**: add `yarn test:e2e`
 
 ### Our Testing Strategy
 
 Glossary:
 
 - Unit Tests: Verify individual functions and components
-- Integration Tests: Test interactions between components
+- Integration Tests: Test interactions between boundaries in the app
 - E2E Tests: Simulate user interactions
-- Manual Tests: Test in development environment
+- Manual Tests: Test in the development environment
 
-| Test Type         | Area under test  | Tool                                             |
-| ----------------- | ---------------- | ------------------------------------------------ |
-| Unit Tests        | Core logic       | Jest                                             |
-| Unit Tests        | React components | Jest + React Testing Library                     |
-| Unit Tests        | React hooks      | Jest + React Testing Library (hooks)             |
-| Integration Tests | API              | Jest + In-memory MongoDB (`@shelf/jest-mongodb`) |
-| Manual Tests      | API              | Postman                                          |
-| Manual Tests      | UI               | Manual in browser                                |
-| E2E Tests         | User workflows   | Playwright                                       |
+| Test Type | Area under test | Tool |
+| --------- | ---------------- | ---- |
+| Unit Tests | Core logic | Jest |
+| Unit Tests | React components and hooks | Jest + React Testing Library |
+| Integration Tests | Backend APIs and service boundaries | Jest |
+| Manual Tests | Local development flows | Browser + API requests |
+| E2E Tests | User workflows | Playwright |
 
-The GitHub repository is configured to run tests automatically via CI/CD after every push to ensure code quality.
+CI runs unit and end-to-end coverage separately, so local development is usually fastest when you mirror that targeted approach instead of defaulting to every test on every change.
 
 ## Manual Testing with Postman
 
-I've created a Postman collection that I use to test the API.
+For backend debugging, start with direct local requests before reaching for a larger collection. A simple health probe is often enough to confirm whether the backend is up and talking to MongoDB:
 
-However, I haven't cleaned it up for public use yet.
-
-If this would be helpful, please let me know by creating a GitHub issue or upvoting the existing one.
+```bash
+curl -i http://localhost:3000/api/health
+```
 
 ![Postman preview](./assets/postman.png)
 

--- a/docs/guides/troubleshoot.md
+++ b/docs/guides/troubleshoot.md
@@ -1,16 +1,31 @@
 # Troubleshoot
 
+## Backend Health Check
+
+Before debugging a deeper auth or sync issue, confirm the backend is actually up:
+
+```bash
+curl -i http://localhost:3000/api/health
+```
+
+Interpret the result like this:
+
+- `200`: the backend is running and can reach MongoDB
+- `500`: the backend is running but database connectivity failed
+- connection refused or timeout: the backend is not listening yet, or the port/base URL is wrong
+
 ## Unable to Sign In with Google in Local Compass Instance
 
 ### Missing User id
 
-When you encounter a missing user id, it is because Compass is not connected to your MongoDB database and there are no records of any user stored. The reason is because you are not connected to the MongoDB database.
+When you encounter a missing user id, Compass usually is not connected to MongoDB or the backend never started cleanly.
 
 Sometimes MongoDB is successfully connected when you run `yarn dev:backend` but you still get a missing user id error. This could be because:
 
-1. The MongoDB connection string in your `.env.local` file is incorrect
+1. The MongoDB connection string in your backend env file is incorrect
 2. Your IP address is not whitelisted in MongoDB Atlas
 3. The MongoDB connection string format is invalid or incomplete
+4. A required backend env variable is missing, so the server exited during startup
 
 ### Mismatch User Id
 

--- a/docs/guides/troubleshoot.md
+++ b/docs/guides/troubleshoot.md
@@ -24,7 +24,7 @@ See the [CLI guide](./cli.md#cleaning-user-data) for more details on deleting us
 
 ### Invalid domain name
 
-When encountering an invalid domain name error, this is because the URL you provided in the `SUPERTOKENS_..` value in your `.env` file is incorrect. This could be caused by prematurely finishing the setup of your Supertokens instance.
+When encountering an invalid domain name error, this is because the URL you provided in the `SUPERTOKENS_..` value in your active environment file is incorrect. For local development that is usually `.env.local`. This could be caused by prematurely finishing the setup of your Supertokens instance.
 
 To fix this:
 

--- a/docs/learn/architecture.md
+++ b/docs/learn/architecture.md
@@ -204,7 +204,7 @@ The backend broadcasts updates to all connected clients for a user.
 
 - Compiled JavaScript (TypeScript → JavaScript)
 - Optimized bundles
-- Environment-specific configuration (`.env.production`)
+- Environment-specific configuration (`.env.local`, `.env.staging`, `.env.production`)
 - Static assets served via Nginx or similar
 - Backend runs as Node.js process (often with PM2)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4727,9 +4727,9 @@ domhandler@^5.0.2, domhandler@^5.0.3:
     domelementtype "^2.3.0"
 
 dompurify@^3.2.5:
-  version "3.2.6"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.2.6.tgz#ca040a6ad2b88e2a92dc45f38c79f84a714a1cad"
-  integrity sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.3.3.tgz#680cae8af3e61320ddf3666a3bc843f7b291b2b6"
+  integrity sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Mostly documentation updates, but `docs/get-started/setup.md` now contains unresolved merge-conflict markers which will break docs rendering. Also bumps `dompurify` in `yarn.lock`, which can affect runtime sanitization behavior if it’s used by the app.
> 
> **Overview**
> **Documentation refresh focused on environment conventions and developer workflows.** Setup/build/deploy/CLI docs are updated to standardize explicit env files (`packages/backend/.env.local|.env.staging|.env.production`), describe which scripts/CLI commands auto-load them, and clarify build outputs (now documented as `/build/web` and `/build/node` with backend `.env` copied into the build).
> 
> **Improves day-to-day dev guidance.** Adds targeted test command recommendations, a backend health-check (`curl .../api/health`) in troubleshooting/testing docs, and refines CLI help/examples (including `delete` flags and migration/seed subcommands).
> 
> **Notable issue:** `docs/get-started/setup.md` includes leftover git conflict markers (`<<<<<<<`, `>>>>>>>`) that should be resolved before merge. `yarn.lock` updates `dompurify` from `3.2.6` to `3.3.3`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 195cfd3972c2d2f98e5e2c0393ab4de6fade5962. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->