### PR TITLE
fix: fill viewport with hero to eliminate homepage whitespace

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -23,6 +23,7 @@ function HomepageHeader() {
           <Link
             className="button button--outline button--secondary button--lg"
             href="https://github.com/SwitchbackTech/compass"
+            style={{ color: "hsl(0, 0%, 95%)", borderColor: "hsl(0, 0%, 95%)" }}
           >
             Read the Code
           </Link>

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -29,6 +29,16 @@
   color: hsl(0, 0%, 95%);
 }
 
+.heroBanner :global(.button--outline) {
+  color: hsl(0, 0%, 95%);
+  border-color: hsl(0, 0%, 95%);
+}
+
+.heroBanner :global(.button--outline:hover) {
+  background: hsla(0, 0%, 95%, 0.12);
+  color: hsl(0, 0%, 95%);
+}
+
 :global([data-theme="dark"]) .heroBanner {
   background: linear-gradient(
     135deg,

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -29,16 +29,6 @@
   color: hsl(0, 0%, 95%);
 }
 
-.heroBanner :global(.button--outline) {
-  color: hsl(0, 0%, 95%);
-  border-color: hsl(0, 0%, 95%);
-}
-
-.heroBanner :global(.button--outline:hover) {
-  background: hsla(0, 0%, 95%, 0.12);
-  color: hsl(0, 0%, 95%);
-}
-
 :global([data-theme="dark"]) .heroBanner {
   background: linear-gradient(
     135deg,

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -9,12 +9,19 @@
   position: relative;
   overflow: hidden;
   color: hsl(0, 0%, 95%);
+  min-height: calc(100vh - var(--ifm-navbar-height));
+  display: flex;
+  align-items: center;
   background: linear-gradient(
     135deg,
     hsl(222, 35%, 18%),
     hsl(214, 60%, 32%),
     hsl(202, 80%, 50%)
   );
+}
+
+.heroBanner > .container {
+  width: 100%;
 }
 
 .heroBanner h1,


### PR DESCRIPTION
## Summary

- After removing the HomepageFeatures section, the Layout wrapper left a large blank white area between the hero and footer
- Hero now uses `min-height: calc(100vh - var(--ifm-navbar-height))` with `display: flex; align-items: center` so it fills the full viewport and the footer sits flush below it

## Test plan

- [ ] Light mode: no white gap between hero and footer
- [ ] Dark mode: same
- [ ] Mobile: hero still fills viewport, buttons still stack correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)