### PR TITLE
Remove docs about nav link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -139,11 +139,6 @@ const config = {
             position: "left",
             label: "Docs",
           },
-          {
-            href: "https://www.compasscalendar.com/blog/about",
-            label: "About",
-            position: "left",
-          },
         ],
       },
       footer: {


### PR DESCRIPTION
## Summary
- remove the `About` link from the docs header nav
- keep the `/blog/about` redirect in place for existing links

## Validation
- `bun run build` (succeeds; existing `docs/README.md -> ../AGENTS.md` broken-link warning remains)
