### PR TITLE
docs: fix broken markdown links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # VSCode
 .vscode
 
+# Claude
+.claude
+
 # Generated files
 .docusaurus
 .cache-loader

--- a/docs/CI-CD/workflows.md
+++ b/docs/CI-CD/workflows.md
@@ -52,7 +52,7 @@ git tag -d v1.2.3
 
 ## Publish Docker Images
 
-Source: [`.github/workflows/publish-docker-images.yml`](../../.github/workflows/publish-docker-images.yml)
+Source: [`.github/workflows/publish-docker-images.yml`](https://github.com/SwitchbackTech/compass/blob/main/.github/workflows/publish-docker-images.yml)
 
 ### How it works
 
@@ -77,7 +77,7 @@ publishing images.
 
 ## Staging Deploy
 
-Source: [`.github/workflows/deploy-staging.yml`](../../.github/workflows/deploy-staging.yml)
+Source: [`.github/workflows/deploy-staging.yml`](https://github.com/SwitchbackTech/compass/blob/main/.github/workflows/deploy-staging.yml)
 
 The deploy workflow SSHes into the staging VPS and runs `./compass update`,
 which pulls the Docker Hub image tag configured by the staging `compass.yaml` file and

--- a/docs/Config/README.md
+++ b/docs/Config/README.md
@@ -66,7 +66,7 @@ Both `google.clientId` and `google.clientSecret` must be real values for Google 
 | `google.webhookUrl` | No | Public HTTPS API URL for Google Calendar push notifications. When omitted, Compass uses `backend.apiUrl`. |
 | `google.notificationToken` | Required for HTTPS Google webhooks | Token used to verify Google Calendar webhook requests. |
 
-See [Google Calendar](./google-calendar.md) for full setup instructions.
+See [Google Calendar](../self-hosting/google-calendar.md) for full setup instructions.
 
 ## Optional Integrations
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 Internal documentation for engineers and agents working in the Compass repo.
 
-Start with [AGENTS.md](../AGENTS.md) for repo rules and command defaults. Use this index for codebase shape, subsystem behavior, and acceptance runbooks.
+Use this index for codebase shape, subsystem behavior, and acceptance runbooks.
 
 ## How docs get published
 
@@ -40,8 +40,8 @@ Markdown files in this `docs/` directory are automatically mirrored to [docs.com
 - [Self-Hosting](./self-hosting/README.md)
 - [Testing Playbook](./development/testing-playbook.md)
 - [Types And Validation](./development/types-and-validation.md)
-- [CI/CD](./ci-cd/README.md)
-- [CLI And Maintenance Commands](./ci-cd/cli-and-maintenance-commands.md)
+- [CI/CD](./ci-cd/workflows.md)
+- [CLI And Maintenance Commands](./development/cli.md)
 - [Versioning](./ci-cd/versioning.md)
 
 ## Feature Deep Dives

--- a/docs/development/hosting-modes.md
+++ b/docs/development/hosting-modes.md
@@ -88,6 +88,6 @@ A few things that trip up new contributors:
 - [Password Auth Flow](../features/password-auth-flow.md)
 - [Offline Storage And Migrations](../features/offline-storage-and-migrations.md)
 - [Local Development](./local-development.md)
-- [Deploy](./deploy.md)
+- [Deploy](../ci-cd/workflows.md#staging-deploy)
 - [Google Sync And SSE Flow](../features/google-sync-and-sse-flow.md)
 - [Backend Route Map](../backend/README.md)

--- a/docs/development/troubleshoot.md
+++ b/docs/development/troubleshoot.md
@@ -73,7 +73,7 @@ bun run cli delete -u <email>
 
 The delete flow removes both Compass data and SuperTokens auth state. The browser cleanup screen only clears local browser storage after the server-side purge is complete.
 
-See [CLI And Maintenance Commands](../ci-cd/cli-and-maintenance-commands.md) for the current delete flow.
+See [CLI And Maintenance Commands](./cli.md) for the current delete flow.
 
 ### Invalid domain name
 

--- a/docs/self-hosting/README.md
+++ b/docs/self-hosting/README.md
@@ -4,7 +4,7 @@ Self-hosting Compass means running it on a server you control instead of using `
 
 Start with [Run Compass on a server](./server-guide.md). It walks through a small VPS setup with your own domain, HTTPS, and the Compass services running behind Caddy.
 
-If you only want to run Compass on your own computer, use the normal local development flow with Bun instead of the self-host installer. See [Run Compass without the installer](./advanced-manual.md).
+If you only want to run Compass on your own computer, use the normal local development flow with Bun instead of the self-host installer. See [Local Development](../development/local-development.md).
 
 ## What Compass is made of
 
@@ -33,9 +33,9 @@ flowchart TD
 ## Start here
 
 - New self-host install: [Run Compass on a server](./server-guide.md)
-- Backups and restore: [Back up and restore your data](./backups-and-restore.md)
+- Backups and restore: [Back up and restore your data](./backup-and-restore.md)
 - Google Calendar: [Add Google Calendar](./google-calendar.md)
-- Manual Bun setup: [Run Compass without the installer](./advanced-manual.md)
+- Manual Bun setup: [Local Development](../development/local-development.md)
 - Monitoring: [Monitoring](./monitoring.md)
 
 ## What you still need to handle yourself

--- a/docs/self-hosting/google-calendar.md
+++ b/docs/self-hosting/google-calendar.md
@@ -163,4 +163,4 @@ The repo has the code paths for Google watches and repair. The self-host Docker 
 
 ## What to read next
 
-If you are using local development, use [Run Compass without the installer](./advanced-manual.md). If you need public Google watch notifications, continue with [Server hosting guide](./server-guide.md).
+If you are using local development, use [Local Development](../development/local-development.md). If you need public Google watch notifications, continue with [Server hosting guide](./server-guide.md).

--- a/docs/self-hosting/server-guide.md
+++ b/docs/self-hosting/server-guide.md
@@ -2,7 +2,7 @@
 
 This guide describes the recommended first server setup for one person hosting Compass on a small VPS. One public domain, Compass on `127.0.0.1`, Caddy in front for HTTPS.
 
-If you only want Compass on your own computer, use the normal Bun-based local setup instead of this self-hosting guide. See [Run Compass without the installer](./advanced-manual.md).
+If you only want Compass on your own computer, use the normal Bun-based local setup instead of this self-hosting guide. See [Local Development](../development/local-development.md).
 
 ## Before you start
 
@@ -338,7 +338,7 @@ See [Connect Google Calendar — Public watch notifications](./google-calendar.m
 
 ## Updating
 
-> **Warning: back up before every update.** `./compass update` rebuilds with newer code. There is no rollback. Back up `~/compass/compass.yaml`, the Mongo volume, and the SuperTokens Postgres volume **together**. See [Backups and restore](./backups-and-restore.md).
+> **Warning: back up before every update.** `./compass update` rebuilds with newer code. There is no rollback. Back up `~/compass/compass.yaml`, the Mongo volume, and the SuperTokens Postgres volume **together**. See [Backups and restore](./backup-and-restore.md).
 
 Then:
 
@@ -363,6 +363,6 @@ should be public, and Caddy should proxy only the web app and `/api`.
 
 ## What to read next
 
-Before your first update, read [Backups and restore](./backups-and-restore.md). If you are adding Google, keep [Google Calendar](./google-calendar.md) open while you test it.
+Before your first update, read [Backups and restore](./backup-and-restore.md). If you are adding Google, keep [Google Calendar](./google-calendar.md) open while you test it.
 
 Have an idea on how this guide can be improved? Let us know in [this GitHub Discussion](https://github.com/SwitchbackTech/compass/discussions/1694).


### PR DESCRIPTION
## Summary
- Repointed several docs links to files that actually exist in this docs tree.
- Swapped missing self-hosting and CI/CD references to the nearest maintained pages.
- Updated workflow source links to GitHub URLs so the site build no longer flags them as broken.
- Ignored `.claude` in `.gitignore`.

## Testing
- Verified all local Markdown links under `docs/` resolve.
- Ran `bun run build` successfully with no broken-link warnings.